### PR TITLE
simplify the Datomic query parser

### DIFF
--- a/datomisca/src/main/scala/DatomiscaQueryParser.scala
+++ b/datomisca/src/main/scala/DatomiscaQueryParser.scala
@@ -1,118 +1,63 @@
 package play.autosource.datomisca
 
 import clojure.{lang => clj}
-import scala.util.{Try, Success, Failure}
-import scala.collection.JavaConverters._
-import scala.collection._
 
-import datomisca._
+import datomisca.DatomicData
 import datomisca.gen.TypedQuery0
 
 object DatomiscaQueryParser {
-  private def withClojure[T](block: => T): T = {
-    val t = Thread.currentThread()
-    val cl = t.getContextClassLoader
-    t.setContextClassLoader(this.getClass.getClassLoader)
-    try block finally t.setContextClassLoader(cl)
-  }
 
-  private def readEDN(edn: String): Try[AnyRef] =
-    Try {
-      withClojure { datomic.Util.read(edn) }
+  private def readEDN(edn: String): Either[String, AnyRef] =
+    try {
+      Right(datomic.Util.read(edn))
+    } catch {
+      case ex: RuntimeException =>
+        Left(s"The supplied query string does not parse as valid EDN: failure(${ex.getMessage}).")
     }
 
-  private def validateDatalog(edn: AnyRef): Either[String, (clj.IPersistentMap, Int, Int)] = {
-    val query = edn match {
+  private val findKW  = clj.Keyword.intern(null, "find")
+  private val inKW    = clj.Keyword.intern(null, "in")
+  private val whereKW = clj.Keyword.intern(null, "where")
+
+  private def validateDatalog(edn: AnyRef): Either[String, clj.IPersistentMap] =
+    edn match {
       case coll: clj.IPersistentMap =>
-        Right(coll)
+        val findClause  = coll.valAt(findKW)
+        val inClause    = coll.valAt(inKW)
+        val whereClause = coll.valAt(whereKW)
+        if ((findClause ne null) &&
+            (inClause eq null) &&
+            (whereClause ne null) &&
+            findClause.isInstanceOf[clj.IPersistentVector] &&
+            findClause.asInstanceOf[clj.IPersistentVector].count == 1 &&
+            whereClause.isInstanceOf[clj.IPersistentVector]) {
+          Right(coll)
+        } else {
+          Left("The supplied query string was a map that did not match the pattern {:find [?e] :where [...]} .")
+        }
       case coll: clj.PersistentVector =>
-        val iter = coll.iterator.asScala.asInstanceOf[Iterator[AnyRef]]
-        transformQuery(iter)
+        if (coll.count > 3) {
+          (coll.nth(0), coll.nth(1), coll.nth(2)) match {
+            case (`findKW`, sym: clj.Symbol, `whereKW`) =>
+              val map = new clj.PersistentArrayMap(Array.empty).asTransient()
+              map.assoc(findKW, clj.PersistentVector.create(sym))
+              map.assoc(whereKW, coll.subList(3, coll.count))
+              Right(map.persistent())
+            case _ =>
+              Left("The supplied query string was a vector that did not match the pattern [:fine ?e :where ...] .")
+          }
+        } else {
+          Left("The supplied query string was a vector that did not have enough elements.")
+        }
       case _ =>
-        Left("Expected a datalog query represented as either a map or a vector")
+        Left("The supplied query string does not parse as a map or a vector.")
     }
 
-    query.right.flatMap{ query =>
-      val outputSize = Option {
-          query.valAt(clj.Keyword.intern(null, "find"))
-        } map { findClause =>
-          Right(findClause.asInstanceOf[clj.IPersistentVector].length)
-        } getOrElse { Left("The :find clause is empty") }
-
-      val inputSize = Option {
-          query.valAt(clj.Keyword.intern(null, "in"))
-        } map { inClause =>
-          Right(inClause.asInstanceOf[clj.IPersistentVector].length)
-        } getOrElse Right(0)
-
-      for {
-        os <- outputSize.right
-        is <- inputSize.right
-      } yield (query, is, os)
-    }
-
-  }
-
-  private def transformQuery(iter: Iterator[AnyRef]): Either[String, clj.IPersistentMap] = {
-    def isQueryKeyword(kw: clj.Keyword): Boolean = {
-      val name = kw.getName
-      (name == "find") || (name == "with") || (name == "in") || (name == "where")
-    }
-    var currKW: Either[String, clj.Keyword] =
-      if (iter.hasNext)
-        iter.next() match {
-          case kw: clj.Keyword if isQueryKeyword(kw) =>
-            Right(kw)
-          case x =>
-            Left(s"Expected a query clause, found value $x with ${x.getClass}")
-        }
-      else
-        Left("Expected a non-empty vector")
-
-    val map = new clj.PersistentArrayMap(Array.empty).asTransient()
-    while (iter.hasNext && currKW.isRight) {
-      val clauseKW = currKW
-      val buf = mutable.Buffer.empty[AnyRef]
-      var shouldContinue = true
-
-      while (shouldContinue && iter.hasNext && currKW.isRight) {
-        iter.next() match {
-          case kw: clj.Keyword =>
-            if (isQueryKeyword(kw)) {
-              currKW = Right(kw)
-              shouldContinue = false
-            } else
-              currKW = Left(s"Unexpected keyword $kw in datalog query")
-
-          case o =>
-            buf += o
-        }
+  def parseTypedQuery0(text: String): Either[String, TypedQuery0[DatomicData]] =
+    readEDN(text).right.flatMap { edn =>
+      validateDatalog(edn).right.map { query =>
+        new TypedQuery0[DatomicData](query)
       }
-
-      if (buf.isEmpty)
-        currKW = Left(s"The $clauseKW clause is empty")
-
-      if(currKW.isRight) { clauseKW.right.map{ c => map.assoc(c, clj.PersistentVector.create(buf.asJava)) } }
     }
 
-    currKW.right.map{ _ => map.persistent() }
-  }
-
-  def parseTypedQuery0(text: String): Either[String, TypedQuery0[DatomicData]] = {
-    readEDN(text).map { edn =>
-      validateDatalog(edn) match {
-        case Left(failure) => Left(s"Request body is not a valid TypedQuery0: failure($failure).")
-        case Right((query, inputSize, outputSize)) =>
-          if (inputSize > 0)
-            Left("Request body is not a valid TypedQuery0: can't accept input params.")
-          else if (outputSize > 1)
-            Left("Request body is not a valid TypedQuery0: can't accept more than 1 output param.")
-          else
-            Right(new TypedQuery0[DatomicData](query))
-      }
-    } match {
-      case Success(r) => r
-      case Failure(e) => Left(s"Request body is not a valid EDN Query: failure(${e.getMessage}).")
-    }
-  }
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -84,7 +84,7 @@ object ApplicationBuild extends Build {
       libraryDependencies ++= Seq(
         "com.pellucid"      %% "datomisca"      % "0.6",
         "com.pellucid"      %% "play-datomisca" % "0.6",
-        "com.datomic"        % "datomic-free"   % "0.8.4218" % "provided" exclude("org.slf4j", "slf4j-nop"),
+        "com.datomic"        % "datomic-free"   % "0.9.4324" % "provided" exclude("org.slf4j", "slf4j-nop"),
         "com.typesafe.play" %% "play"           % "2.2.1"    % "provided"
       )
     )


### PR DESCRIPTION
- the original code was copied from Datomisca, this cuts it down to a simplified form that is suited for the purpose of Autosource
- queries must be of the form `[:find ?e :where …]` or `{:find [?e] :where […]}`
- upgrade to the latest Datomic version
