### PR TITLE
upgraded reactive-mongo and play-reactive-mongo dependency

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -63,8 +63,8 @@ object ApplicationBuild extends Build {
 
       resolvers += "Sonatype Snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/",
       libraryDependencies ++= Seq(
-        "org.reactivemongo" %% "play2-reactivemongo" % "0.10.0-SNAPSHOT",
-        "org.reactivemongo" %% "reactivemongo"       % "0.10.0-SNAPSHOT",
+        "org.reactivemongo" %% "play2-reactivemongo" % "0.10.1",
+        "org.reactivemongo" %% "reactivemongo"       % "0.10.0",
         "com.typesafe.play" %% "play"                % "2.2.1"        % "provided"
       )
     )


### PR DESCRIPTION
Upgraded dependency as current build is not stable due to missing snapshot dependency from repo

module not found: org.reactivemongo#play2-reactivemongo_2.10;0.10.0-SNAPSHOT
