### PR TITLE
Check if limit == 0 in SlickDao#find

### DIFF
--- a/slick/src/main/scala/slick/dao/SlickDaoProfile.scala
+++ b/slick/src/main/scala/slick/dao/SlickDaoProfile.scala
@@ -82,7 +82,7 @@ trait SlickDaoProfile {
       }
 
     def find(limit: Int = 0, skip: Int = 0)(implicit session: Session): Seq[E] =
-      this.drop(skip).take(limit).list
+      if (limit > 0) this.drop(skip).take(limit).list else this.drop(skip).list
 
   }
 }


### PR DESCRIPTION
Title explains it all.
If you didn't specify a limit a call on http://localhost:9000/model would return an empty array.
